### PR TITLE
Support nginx 1.9.11+

### DIFF
--- a/ngx_http_rdns_module.c
+++ b/ngx_http_rdns_module.c
@@ -240,7 +240,11 @@ static char * merge_loc_conf(ngx_conf_t * cf, void * parent, void * child) {
     }
 #endif
 
+#if (nginx_version > 1009010)
+    if (conf->conf.enabled && ((core_loc_cf->resolver == NULL) || (core_loc_cf->resolver->connections.nelts == 0))) {
+#else
     if (conf->conf.enabled && ((core_loc_cf->resolver == NULL) || (core_loc_cf->resolver->udp_connections.nelts == 0))) {
+#endif
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "no core resolver defined for rdns");
         return NGX_CONF_ERROR;
     }


### PR DESCRIPTION
Nginx 1.9.11+ has modifed the udp_connections to connections in ngx_resolver_t struct
https://github.com/nginx/nginx/commit/1945fff7bfee1eef23933faa0ccfbe05445dcfe1